### PR TITLE
add FrameInput/RuleContext and SoftDropRule

### DIFF
--- a/app/src/main/java/com/burtsnyder/blockengine/core/engine/GameManager.java
+++ b/app/src/main/java/com/burtsnyder/blockengine/core/engine/GameManager.java
@@ -1,31 +1,43 @@
 package com.burtsnyder.blockengine.core.engine;
 
-import com.burtsnyder.blockengine.core.actor.Actor;
-import com.burtsnyder.blockengine.core.board.Grid;
+import com.burtsnyder.blockengine.core.input.FrameInput;
 import com.burtsnyder.blockengine.core.input.InputAction;
+import com.burtsnyder.blockengine.core.rules.RuleContext;
 import com.burtsnyder.blockengine.core.rules.interfaces.Rule;
 import com.burtsnyder.blockengine.platform.interfaces.GameEngine;
-import com.burtsnyder.boxrift.actor.Boxriftle;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 public class GameManager implements GameEngine {
     private final GameState state;
     private final List<Rule> rules = new ArrayList<>();
 
+    // per-frame input + context
+    private final FrameInput frameInput = new FrameInput();
+    private final RuleContext frameCtx = new RuleContext(frameInput);
+
     public GameManager(int col, int row) {
-        this.state = new GameState(col,row);
+        this.state = new GameState(col, row);
     }
+
+    public GameState getState() { return state; }
 
     public void addRule(Rule rule) {
         rules.add(rule);
+        rules.sort(Comparator.comparingInt(Rule::priority));
+    }
+
+    public void enqueueActions(Iterable<InputAction> actions) {
+        frameInput.enqueue(actions);
     }
 
     public void applyRules() {
         for (Rule rule : rules) {
-            rule.apply(state);
+            rule.apply(state, frameCtx);   // ✅ pass context
         }
+        frameCtx.reset(); // remove inhibitions...
     }
 
     @Override
@@ -33,36 +45,7 @@ public class GameManager implements GameEngine {
         applyRules();
     }
 
-    public GameState getState() {
-        return state;
-    }
-
     public void applyInput(InputAction a) {
-        switch (a) {
-            case MOVE_LEFT  -> tryShift(-1, 0);
-            case MOVE_RIGHT -> tryShift(+1, 0);
-            case SOFT_DOWN  -> tryShift(0, +1);
-        }
-    }
-
-    private void tryShift(int dx, int dy) {
-        var p = state.getActivePiece();
-        if (p == null) return;
-        var moved = (Actor) p.move(dx, dy);
-        if (canPlace(moved, state.getGrid())) {
-            state.setActivePiece((Boxriftle)moved);
-        }
-    }
-
-    private boolean canPlace(Actor actor, Grid grid) {
-        var o = actor.getOrigin();
-        for (var b : actor.getBlocks()) {
-            var p = b.getPosition();
-            int x = o.x() + p.x();
-            int y = o.y() + p.y();
-            if (!grid.inBounds(x, y)) return false;
-            if (!grid.isEmpty(x, y)) return false;
-        }
-        return true;
+        frameInput.enqueue(List.of(a));
     }
 }

--- a/app/src/main/java/com/burtsnyder/blockengine/core/engine/GameState.java
+++ b/app/src/main/java/com/burtsnyder/blockengine/core/engine/GameState.java
@@ -17,9 +17,7 @@ public class GameState {
         return nextPieceId++;
     }
 
-    public GameState(int col, int row) {
-        this.grid = new Grid(col,row);
-    }
+    public GameState(int col, int row) { this.grid = new Grid(col,row);}
 
     public void setActivePiece(Boxriftle piece) {
         this.activePiece = piece;

--- a/app/src/main/java/com/burtsnyder/blockengine/core/input/FrameInput.java
+++ b/app/src/main/java/com/burtsnyder/blockengine/core/input/FrameInput.java
@@ -1,0 +1,29 @@
+package com.burtsnyder.blockengine.core.input;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+public final class FrameInput {
+    private final Deque<InputAction> queue = new ArrayDeque<>();
+
+    public void enqueue(Iterable<InputAction> actions) {
+        for (var a : actions) queue.addLast(a);
+    }
+
+    public InputAction poll() {
+        return queue.pollFirst();
+    }
+
+
+
+    public boolean consumeIf(Predicate<InputAction> p) {
+        for (Iterator<InputAction> it = queue.iterator(); it.hasNext();) {
+            var a = it.next();
+            if (p.test(a)) { it.remove(); return true; }
+        }
+        return false;
+    }
+    public void clear() { queue.clear(); }
+}

--- a/app/src/main/java/com/burtsnyder/blockengine/core/rules/BaseRule.java
+++ b/app/src/main/java/com/burtsnyder/blockengine/core/rules/BaseRule.java
@@ -5,11 +5,14 @@ import com.burtsnyder.blockengine.core.rules.interfaces.Rule;
 
 public abstract class BaseRule implements Rule {
     protected final GameState state;
+    protected final RuleContext ruleContext;
 
     public BaseRule(GameState state) {
+        this.ruleContext = null;
         this.state = state;
     }
+
     @Override
-    public abstract void apply(GameState state);
+    public abstract void apply(GameState state, RuleContext ctx);
 }
 

--- a/app/src/main/java/com/burtsnyder/blockengine/core/rules/Inhibition.java
+++ b/app/src/main/java/com/burtsnyder/blockengine/core/rules/Inhibition.java
@@ -1,0 +1,3 @@
+package com.burtsnyder.blockengine.core.rules;
+
+public enum Inhibition { GRAVITY }

--- a/app/src/main/java/com/burtsnyder/blockengine/core/rules/RuleContext.java
+++ b/app/src/main/java/com/burtsnyder/blockengine/core/rules/RuleContext.java
@@ -1,0 +1,25 @@
+package com.burtsnyder.blockengine.core.rules;
+
+import java.util.EnumSet;
+import com.burtsnyder.blockengine.core.input.FrameInput;
+import java.util.EnumSet;
+
+
+/**
+ *  supress a rule
+ */
+public final class RuleContext {
+    public enum Inhibition { GRAVITY }
+
+    private final EnumSet<Inhibition> inhibitions = EnumSet.noneOf(Inhibition.class);
+    private final FrameInput input;
+
+    public RuleContext(FrameInput input) { this.input = input; }
+
+    public FrameInput input() { return input; }
+
+    public void inhibit(Inhibition i) { inhibitions.add(i); }
+    public boolean isInhibited(Inhibition i) { return inhibitions.contains(i); }
+
+    public void reset() { inhibitions.clear(); input.clear(); }
+}

--- a/app/src/main/java/com/burtsnyder/blockengine/core/rules/interfaces/Rule.java
+++ b/app/src/main/java/com/burtsnyder/blockengine/core/rules/interfaces/Rule.java
@@ -2,9 +2,15 @@
 package com.burtsnyder.blockengine.core.rules.interfaces;
 
 import com.burtsnyder.blockengine.core.engine.GameState;
+import com.burtsnyder.blockengine.core.rules.RuleContext;
 
 public interface Rule {
-    void apply(GameState state);
+    int priority(); // lower runs first
+    void apply(GameState state, RuleContext ctx);
+
+    // for 1-arg method possibly
+    default void apply(GameState state) { apply(state, null); }
 }
+
 
 

--- a/app/src/main/java/com/burtsnyder/boxrift/Game.java
+++ b/app/src/main/java/com/burtsnyder/boxrift/Game.java
@@ -8,7 +8,8 @@ public class Game {
         new JavaFXGameLoop(
                 BlockConfig.BLOCK_SIZE,
                 BlockConfig.GRID_COLUMNS,
-                BlockConfig.GRID_ROWS
+                BlockConfig.GRID_ROWS,
+                BlockConfig.GAME_NAME
                 ).launchJavaFX();
     }
 }

--- a/app/src/main/java/com/burtsnyder/boxrift/config/BlockConfig.java
+++ b/app/src/main/java/com/burtsnyder/boxrift/config/BlockConfig.java
@@ -4,6 +4,7 @@ public final class BlockConfig {
     public static final int BLOCK_SIZE = 38;
     public static final int GRID_COLUMNS = 10;
     public static final int GRID_ROWS = 20;
+    public static final String GAME_NAME = "Boxrift";
 
     private BlockConfig() {}
 }

--- a/app/src/main/java/com/burtsnyder/boxrift/rules/GravityRule.java
+++ b/app/src/main/java/com/burtsnyder/boxrift/rules/GravityRule.java
@@ -2,14 +2,53 @@ package com.burtsnyder.boxrift.rules;
 
 import com.burtsnyder.blockengine.core.engine.GameState;
 import com.burtsnyder.blockengine.core.rules.BaseRule;
+import com.burtsnyder.blockengine.core.rules.RuleContext;
+
+import java.util.function.LongSupplier;
+
+import static com.burtsnyder.blockengine.core.rules.RuleContext.Inhibition.GRAVITY;
 
 public class GravityRule extends BaseRule {
-    public GravityRule(GameState state) { super(state); }
+    private final LongSupplier clockNanos;
+    private final long intervalNanos;
+    private long lastDropAt = 0;
+
+    public GravityRule(GameState state) {
+        this(state, System::nanoTime, 1000);
+    }
+    public GravityRule(GameState state, long gravityMs) {
+        this(state, System::nanoTime, gravityMs);
+    }
+
+    /**
+     * @param gravityMs interval between automatic drops (milliseconds)
+     */
+    public GravityRule(GameState state, LongSupplier clockNanos, long gravityMs) {
+        super(state);
+        this.clockNanos= clockNanos;
+        this.intervalNanos = gravityMs * 1_000_000L;
+    }
 
     @Override
-    public void apply(GameState state) {
+    public int priority() {
+        return 50;
+    }
+
+    @Override
+    public void apply(GameState state, RuleContext ctx) {
+        if (ctx.isInhibited(GRAVITY)) return;// gravity rule inhibited
+
+        long now = clockNanos.getAsLong();
+        if (now - lastDropAt < intervalNanos) return;
+
         var piece = state.getActivePiece();
         if (piece == null) return;
-        state.setActivePiece(piece.move(0, 1));
+
+        var down = piece.move(0, 1);
+
+        // todo: trigger lock/land behavior (....state.lockActivePiece())
+
+        state.setActivePiece(down);
+        lastDropAt = now;
     }
 }

--- a/app/src/main/java/com/burtsnyder/boxrift/rules/LateralMoveRule.java
+++ b/app/src/main/java/com/burtsnyder/boxrift/rules/LateralMoveRule.java
@@ -1,0 +1,54 @@
+package com.burtsnyder.boxrift.rules;
+
+import com.burtsnyder.blockengine.core.actor.Actor;
+import com.burtsnyder.blockengine.core.engine.GameState;
+import com.burtsnyder.blockengine.core.input.InputAction;
+import com.burtsnyder.blockengine.core.rules.BaseRule;
+import com.burtsnyder.blockengine.core.rules.RuleContext;
+
+import static com.burtsnyder.blockengine.core.rules.RuleContext.Inhibition.GRAVITY;
+
+public class LateralMoveRule extends BaseRule {
+    public LateralMoveRule(GameState state) {
+        super(state);
+    }
+
+    @Override public int priority() { return 0; }
+
+    @Override
+    public void apply(GameState state, RuleContext ctx) {
+        boolean movedAny = false;
+        while (true) {
+            boolean moved =
+                    ctx.input().consumeIf(a -> a == InputAction.MOVE_LEFT)  && tryMove(state, -1, 0)
+                            || ctx.input().consumeIf(a -> a == InputAction.MOVE_RIGHT) && tryMove(state,  1, 0);
+
+            if (!moved) break;
+            movedAny = true;
+        }
+        if (movedAny) ctx.inhibit(GRAVITY);
+    }
+
+    private boolean tryMove(GameState state, int dx, int dy) {
+        var piece = state.getActivePiece();
+        if (piece == null) return false;
+        var moved = piece.move(dx, dy);
+        if (!inBounds(state, moved)) return false;   // minimal wall ceileing check
+        state.setActivePiece(moved);
+        return true;
+    }
+
+
+
+    private boolean inBounds(GameState state, Actor actor) {
+        var g = state.getGrid();
+        var o = actor.getOrigin();
+        for (var b : actor.getBlocks()) {
+            var p = b.getPosition();
+            int x = o.x() + p.x();
+            int y = o.y() + p.y();
+            if (x < 0 || x >= g.getWidth() || y < 0 || y >= g.getHeight()) return false;
+        }
+        return true;
+    }
+}

--- a/app/src/main/java/com/burtsnyder/boxrift/rules/SoftDropRule.java
+++ b/app/src/main/java/com/burtsnyder/boxrift/rules/SoftDropRule.java
@@ -1,0 +1,49 @@
+package com.burtsnyder.boxrift.rules;
+
+import com.burtsnyder.blockengine.core.engine.GameState;
+import com.burtsnyder.blockengine.core.rules.BaseRule;
+import com.burtsnyder.blockengine.core.rules.RuleContext;
+import com.burtsnyder.blockengine.core.input.InputAction;
+
+import static com.burtsnyder.blockengine.core.rules.RuleContext.Inhibition.GRAVITY;
+
+public class SoftDropRule extends BaseRule {
+    public SoftDropRule(GameState state) {
+        super(state);
+    }
+
+    @Override public int priority() { return 25; } // after lateral 0, before gravity  50
+
+    @Override
+    public void apply(GameState state, RuleContext ctx) {
+        boolean dropped = false;
+        while (ctx.input().consumeIf(a -> a == InputAction.SOFT_DOWN)) {
+            if (tryDown(state)) dropped = true;
+            else break; // reached floor no more...
+        }
+        if (dropped) ctx.inhibit(GRAVITY);
+    }
+
+    private boolean tryDown(GameState state) {
+        var piece = state.getActivePiece();
+        if (piece == null) return false;
+        var down = piece.move(0, 1);
+
+        // todo: collision det
+        if (!inBounds(state, down)) return false;
+
+        state.setActivePiece(down);
+        return true;
+    }
+
+    private boolean inBounds(GameState state, com.burtsnyder.blockengine.core.actor.Actor actor) {
+        var g = state.getGrid();
+        var o = actor.getOrigin();
+        for (var b : actor.getBlocks()) {
+            var p = b.getPosition();
+            int x = o.x() + p.x(), y = o.y() + p.y();
+            if (x < 0 || x >= g.getWidth() || y < 0 || y >= g.getHeight()) return false;
+        }
+        return true;
+    }
+}

--- a/app/src/main/java/com/burtsnyder/boxrift/rules/SpawnRule.java
+++ b/app/src/main/java/com/burtsnyder/boxrift/rules/SpawnRule.java
@@ -2,6 +2,7 @@ package com.burtsnyder.boxrift.rules;
 
 import com.burtsnyder.blockengine.core.engine.GameState;
 import com.burtsnyder.blockengine.core.rules.BaseRule;
+import com.burtsnyder.blockengine.core.rules.RuleContext;
 import com.burtsnyder.blockengine.util.Coord;
 import com.burtsnyder.boxrift.actor.Boxriftle;
 import com.burtsnyder.boxrift.actor.BoxriftleFactory;
@@ -15,7 +16,12 @@ public class SpawnRule extends BaseRule {
     public SpawnRule(GameState state) { super(state); }
 
     @Override
-    public void apply(GameState state) {
+    public int priority() {
+        return -100; // spawn before movem/gravity
+    }
+
+    @Override
+    public void apply(GameState state, RuleContext ctx) {
         if (state.getActivePiece() != null) return;
 
         var grid = state.getGrid();
@@ -26,10 +32,12 @@ public class SpawnRule extends BaseRule {
         BlockSetType type = types[random.nextInt(types.length)];
         Boxriftle piece = new BoxriftleFactory(type).createAt(new Coord(spawnX, spawnY));
 
-        long pieceId = state.generateNextPieceId();
-        long groupId = state.generateNextGroupId();
-        piece.setId(pieceId);
-        piece.setGroupId(groupId);
+        // ids
+        piece.setId(state.generateNextPieceId());
+        piece.setGroupId(state.generateNextGroupId());
+
+
+        //todo: set a game-over flag or trigger a TopOutRule
 
         state.setActivePiece(piece);
     }

--- a/app/src/main/java/com/burtsnyder/boxrift/ui/libgdx/view/LibGDXGameLoop.java
+++ b/app/src/main/java/com/burtsnyder/boxrift/ui/libgdx/view/LibGDXGameLoop.java
@@ -1,0 +1,14 @@
+package com.burtsnyder.boxrift.ui.libgdx.view;
+
+import com.burtsnyder.blockengine.core.engine.GameLoop;
+import com.burtsnyder.blockengine.core.input.InputBus;
+
+public class LibGDXGameLoop extends GameLoop {
+
+    public LibGDXGameLoop(int blockSize, int col, int row, InputBus inputBus) {
+        super(blockSize, col, row, inputBus);
+    }
+
+    @Override
+    public void start() {}
+}

--- a/app/src/main/java/module-info.java
+++ b/app/src/main/java/module-info.java
@@ -15,4 +15,6 @@ open module com.burtsnyder.boxrift.app {
     exports com.burtsnyder.blockengine.core.types;
     exports com.burtsnyder.boxrift.ui.javafx;
     exports com.burtsnyder.boxrift.ui.javafx.view;
+    exports com.burtsnyder.blockengine.core.rules;
+    exports com.burtsnyder.blockengine.core.input.keyboard;
 }


### PR DESCRIPTION
consumes SOFT_DOWN actions from FrameInput
Moves piece down immediately and repeatedly when key is held
Inhibits gravity for the same frame to avoid double-drops
Placed after LateralMoveRule (priority 25) and before GravityRule (priority 50)